### PR TITLE
basic認証の記述修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+  # 以下を追記
+  def production?
+    Rails.env.production?
+  end
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
@@ -19,26 +23,5 @@ class ApplicationController < ActionController::Base
     end
   end
 
-
-  protected
-
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :email, :password,profile_attributes: [:first_name, :family_name, :first_name_kana, :family_name_kana, :birth_day, :birth_month, :birth_year],address_attributes: [:post_code, :prefecture_id, :city, :house_number, :building_name, :telephone_number,]])
-  end
-
-    private
-    # 以下を追記
-    def production?
-      Rails.env.production?
-    end
-
-
-  before_action :basic_auth, if: :production?
-
-private
-# 以下を追記
-def production?
-  Rails.env.production?
-end
 
 end


### PR DESCRIPTION
 [WIP] basic認証の修正
What
• basic認証を実装
Why
• basic認証が本番環境で作動しないため修正
• スプリントレビューに必要な実装のため
• application_controller.rbの記述のコードの冗長性を削除
